### PR TITLE
fix typo in docs

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -102,9 +102,9 @@ Its principal developers are
 
 Further contributions to ReadVTK have been made by the following people:
 * [Jorge Pérez Zerpa](https://www.fing.edu.uy/~jorgepz/)
-(Universidad de la República, Uruguay)
+  (Universidad de la República, Uruguay)
 * [Ondřej Kincl](https://www2.karlin.mff.cuni.cz/~kincl/)
-(Charles University, Czech Republic)
+  (Charles University, Czech Republic)
 * [Boris Kaus](https://www.geosciences.uni-mainz.de/geophysics-and-geodynamics/team/univ-prof-dr-boris-kaus/)
   (Johannes-Gutenberg University Mainz, Germany)
 


### PR DESCRIPTION
The previous version makes the docs look like

![image](https://user-images.githubusercontent.com/12693098/229116378-55276dc4-6a04-4c7d-99b3-a634c2c34a93.png)
