### PR TITLE
update to VTKBase.jl

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -24,7 +24,7 @@ jobs:
       - name: "Run CompatHelper"
         run: |
           import CompatHelper
-          CompatHelper.main()
+          CompatHelper.main(; subdirs=["", "docs", "test"])
         shell: julia --color=yes {0}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Project.toml
+++ b/Project.toml
@@ -8,8 +8,10 @@ Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 LightXML = "9c8b4983-aa76-5018-a973-4c85ecc9e179"
+VTKBase = "4004b06d-e244-455f-a6ce-a5f9919cc534"
 
 [compat]
 CodecZlib = "0.7"
 LightXML = "0.9"
+VTKBase = "1"
 julia = "1.6"

--- a/Project.toml
+++ b/Project.toml
@@ -8,10 +8,12 @@ Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 LightXML = "9c8b4983-aa76-5018-a973-4c85ecc9e179"
+Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 VTKBase = "4004b06d-e244-455f-a6ce-a5f9919cc534"
 
 [compat]
 CodecZlib = "0.7"
 LightXML = "0.9"
+Reexport = "1"
 VTKBase = "1"
 julia = "1.6"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,7 +1,8 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+ReadVTK = "dc215faf-f008-4882-a9f7-a79a826fadc3"
 VTKBase = "4004b06d-e244-455f-a6ce-a5f9919cc534"
 
 [compat]
 Documenter = "0.27"
-VTKBase = "1.0"
+VTKBase = "1.0.1"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,5 +1,7 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+VTKBase = "4004b06d-e244-455f-a6ce-a5f9919cc534"
 
 [compat]
 Documenter = "0.27"
+VTKBase = "1.0"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,14 +1,28 @@
 using Documenter
 import Pkg
+using VTKBase
 using ReadVTK
 
 # Define module-wide setups such that the respective modules are available in doctests
+DocMeta.setdocmeta!(VTKBase, :DocTestSetup, :(using VTKBase); recursive = true)
 DocMeta.setdocmeta!(ReadVTK, :DocTestSetup, :(using ReadVTK); recursive=true)
+
+# Path to markdown file containing docs for VTKBase.jl
+# We copy the file to src/external/
+vtkbase_docs_src = joinpath(
+    dirname(dirname(pathof(VTKBase))),  # VTKBase directory
+    "docs",
+    "src",
+    "VTKBase.md",
+)
+isfile(vtkbase_docs_src) || error("file not found: $vtkbase_docs_src")
+vtkbase_docs = joinpath("external", "VTKBase.md")
+cp(vtkbase_docs_src, joinpath(@__DIR__, "src", vtkbase_docs); force = true)
 
 # Make documentation
 makedocs(
     # Specify modules for which docstrings should be shown
-    modules = [ReadVTK],
+    modules = [VTKBase, ReadVTK],
     # Set sitename to ReadVTK
     sitename="ReadVTK.jl",
     # Provide additional formatting options
@@ -24,6 +38,7 @@ makedocs(
     pages = [
         "Home" => "index.md",
         "Reference" => "reference.md",
+        "VTKBase.jl" => vtkbase_docs,
         "Contributing" => "contributing.md",
         "License" => "license.md"
     ],

--- a/docs/src/external/.gitignore
+++ b/docs/src/external/.gitignore
@@ -1,0 +1,3 @@
+# Files in this directory are "generated" by make.jl
+*.md
+

--- a/src/ReadVTK.jl
+++ b/src/ReadVTK.jl
@@ -8,7 +8,8 @@ using CodecZlib: ZlibDecompressor
 using LightXML: LightXML, XMLDocument, XMLElement, parse_string, attribute, has_attribute,
                 child_elements, free, content, find_element
 
-using VTKBase: VTKBase
+using Reexport: @reexport
+@reexport using VTKBase
 
 export VTKFile, VTKData, VTKDataArray, VTKCells, VTKPrimitives,           # structs
        PVTKFile, PVTKData, PVTKDataArray, PVDFile,

--- a/src/ReadVTK.jl
+++ b/src/ReadVTK.jl
@@ -8,6 +8,8 @@ using CodecZlib: ZlibDecompressor
 using LightXML: LightXML, XMLDocument, XMLElement, parse_string, attribute, has_attribute,
                 child_elements, free, content, find_element
 
+using VTKBase: VTKBase
+
 export VTKFile, VTKData, VTKDataArray, VTKCells, VTKPrimitives,           # structs
        PVTKFile, PVTKData, PVTKDataArray, PVDFile,
        get_point_data, get_cell_data, get_data, get_data_reshaped,        # get data functions

--- a/src/ReadVTK.jl
+++ b/src/ReadVTK.jl
@@ -9,7 +9,7 @@ using LightXML: LightXML, XMLDocument, XMLElement, parse_string, attribute, has_
                 child_elements, free, content, find_element
 
 using Reexport: @reexport
-@reexport using VTKBase
+@reexport using VTKBase: VTKBase
 
 export VTKFile, VTKData, VTKDataArray, VTKCells, VTKPrimitives,           # structs
        PVTKFile, PVTKData, PVTKDataArray, PVDFile,


### PR DESCRIPTION
This is just the basic template for the update to use types from VTKBase.jl. Building the docs works and we can use this as a starting point for further extensions.