### PR TITLE
Added ParaView file output read ability.

### DIFF
--- a/src/ReadVTK.jl
+++ b/src/ReadVTK.jl
@@ -16,7 +16,8 @@ export VTKFile, VTKData, VTKDataArray, VTKCells, VTKPrimitives,           # stru
        get_point_data, get_cell_data, get_data, get_data_reshaped,        # get data functions
        get_points, get_cells, get_origin, get_spacing, get_primitives,    # get geometry functions
        get_coordinates, get_coordinate_data,                              # get geometry functions
-       get_example_file                                                   # other functions
+       get_example_file,                                                  # other functions
+       convert_VTKCells_to_MeshCells                                      # conversion utility
 
 """
     VTKFile
@@ -1137,6 +1138,29 @@ function get_example_file(filename; head="main", output_directory=".", force=fal
   end
 
   return filepath
+end
+
+"""
+    convert_VTKCells_to_MeshCells(cells::VTKCells)
+
+Converts the `VTKCells` type, which holds data on N number of cells, to
+a vector of N number of `MeshCell` types. Allows for the reading and then
+subsequent writing with `WriteVTK`.
+
+See also: [`VTKCells`](@ref), [`MeshCell`](@ref)
+"""
+function convert_VTKCells_to_MeshCells(cells::VTKCells)
+
+  start_offsets = [0; cells.offsets[1:end-1]] .+ 1
+  end_offsets = cells.offsets
+
+  offset_ranges = range.(start_offsets, end_offsets)
+
+  connectivity = getindex.([cells.connectivity], offset_ranges)
+  cell_types = VTKBase.VTKCellType.(cells.types)
+
+  return VTKBase.MeshCell.(cell_types, connectivity)
+
 end
 
 end # module

--- a/src/ReadVTK.jl
+++ b/src/ReadVTK.jl
@@ -610,8 +610,14 @@ function VTKDataArray(xml_element, vtk_file::VTKFile)
   # Extract information about the underlying data
   data_type = string_to_data_type(attribute(xml_element, "type", required=true))
   name = attribute(xml_element, "Name", required=true)
-  n_components = parse(Int, attribute(xml_element, "NumberOfComponents", required=true))
   format_string = attribute(xml_element, "format", required=true)
+
+  # ParaView doesn't include NumberOfComponents tag if field is a scalar
+  if has_attribute(xml_element, "NumberOfComponents")
+    n_components = parse(Int, attribute(xml_element, "NumberOfComponents", required=true))
+  else
+    n_components = 1
+  end
 
   # An offset is only used when the format is `appended`
   if has_attribute(xml_element, "offset")
@@ -657,7 +663,8 @@ function get_data(data_array::VTKDataArray{T,N,<:FormatBinary}) where {T,N}
   # * first get the content of the corresponding XML data array
   # * then remove leading/trailing whitespace
   # * finally decode from Base64 to binary representation
-  raw = base64decode(strip(content(data_array.data_array)))
+  # * split with "\n" added to read ParaView output files
+  raw = base64decode(split(strip(content(data_array.data_array)), "\n")[1])
 
   if is_compressed(data_array)
     # If data is stored compressed, the first four integers of type `header_type` are the header and

--- a/src/ReadVTK.jl
+++ b/src/ReadVTK.jl
@@ -1143,9 +1143,8 @@ end
 """
     convert_VTKCells_to_MeshCells(cells::VTKCells)
 
-Converts the `VTKCells` type, which holds data on N number of cells, to
-a vector of N number of `MeshCell` types. Allows for the reading and then
-subsequent writing with `WriteVTK`.
+Convert a `VTKCells` object, which holds raw point and connectivity data for a number of cells, to
+a vector of `MeshCell` objects. The latter can, e.g., be passed to the WriteVTK.jl package for writing new VTK files.
 
 See also: [`VTKCells`](@ref), [`MeshCell`](@ref)
 """

--- a/test/paraview_tests.jl
+++ b/test/paraview_tests.jl
@@ -1,0 +1,62 @@
+
+vtk_case1 = VTKFile(get_test_example_file("celldata_inline_binary_uncompressed.vtu"))
+vtk_case2 = VTKFile(get_test_example_file("celldata_inline_binary_uncompressed_ParaView.vtu"))
+
+points1 = get_points(vtk_case1)
+points2 = get_points(vtk_case2)
+
+cells1 = get_cells(vtk_case1)
+cells2 = get_cells(vtk_case2)
+
+cell_data1 = get_cell_data(vtk_case1)
+cell_data2 = get_cell_data(vtk_case2)
+
+vtk_keys1 = keys(cell_data1)
+vtk_keys2 = keys(cell_data2)
+
+@testset "read points and cells" begin
+
+  @test points1 == points2
+  @test cells1.connectivity == cells2.connectivity
+  @test cells1.offsets == cells2.offsets
+  @test cells1.types == cells2.types
+
+end
+
+@testset "read cell data" begin
+
+  @test vtk_keys1 == vtk_keys2
+
+  for (key1, key2) in zip(vtk_keys1, vtk_keys2)
+    @test get_data(cell_data1[key1]) == get_data(cell_data2[key2])
+  end
+
+end
+
+write_vtk_out1 = joinpath(TEST_EXAMPLES_DIR, "write_vtk_out1")
+write_vtk_out2 = joinpath(TEST_EXAMPLES_DIR, "write_vtk_out2")
+
+vtk_grid(write_vtk_out1, points1, convert_VTKCells_to_MeshCells(cells1)) do vtk
+
+  for key1 in vtk_keys1
+    vtk[key1] = get_data(cell_data1[key1])
+  end
+
+end
+
+vtk_grid(write_vtk_out2, points2, convert_VTKCells_to_MeshCells(cells2)) do vtk
+
+  for key2 in vtk_keys2
+    vtk[key2] = get_data(cell_data2[key2])
+  end
+
+end
+
+write_vtk_out1_UInt8 = read(write_vtk_out1 * ".vtu")
+write_vtk_out2_UInt8 = read(write_vtk_out2 * ".vtu")
+
+@testset "write consistency" begin
+
+  @test write_vtk_out1_UInt8 == write_vtk_out2_UInt8
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -408,4 +408,14 @@ clean_directory(TEST_EXAMPLES_DIR) = @test_nowarn rm(TEST_EXAMPLES_DIR, recursiv
     clean_directory(TEST_EXAMPLES_DIR)
   end
 
+  @testset "ParaView format read and write" begin
+    # Start with a clean environment: remove example file directory if it exists
+    create_directory(TEST_EXAMPLES_DIR)
+
+    include("paraview_tests.jl")
+
+    # Clean up afterwards: delete example file directory
+    clean_directory(TEST_EXAMPLES_DIR)
+  end
+
 end


### PR DESCRIPTION
This PR adds the lines needed to read the slightly different ParaView output format of VTKs. The base64decode needed another filter for the raw data. ParaView also doesn't give the "NumberOfComponents" tag to scalars, so that line was changed per issue #20 

Also added some tests that read to files with identical data, but one was read and then re-output by ParaView. I've submitted a PR for that test file in the examples repo. 

Lastly the "convert_VTKCells_to_MeshCells" does what it says. It can be named something better, but at least its here to show how to convert between VTKCells style to MeshCells. 

I realized after the first commit here, that this function probably should have been a separate PR. Sorry about that, still learning the ropes. I can redo everything if necessary.

Please let me know any concerns or suggestions you have.