### PR TITLE
Adds VTKCells converter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ coverage_report/
 /*.vtu
 /*.vti
 test/examples
+/.vscode

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Further contributions to ReadVTK have been made by the following people:
 (Charles University, Czech Republic)
 * [Boris Kaus](https://www.geosciences.uni-mainz.de/geophysics-and-geodynamics/team/univ-prof-dr-boris-kaus/)
   (Johannes-Gutenberg University Mainz, Germany)
+* [Matthew Whisenant](https://volweb2.utk.edu/~mwhisena/)
 
 ## License and contributing
 ReadVTK is licensed under the MIT license (see [LICENSE.md](LICENSE.md)).

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -58,7 +58,7 @@ julia> data = get_data(element_ids)
  3085
 ```
 
-After modifications to the read VTK data, one can write back using WriteVTK.jl but must first convert cell objects using `to_meshcells`. 
+After modifications to the read VTK data, one can write back using [WriteVTK.jl](https://github.com/JuliaVTK/WriteVTK.jl) but must first convert cell objects using `to_meshcells`. 
 Continuing from the REPL code above:
 ```julia
 julia> using WriteVTK

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -58,6 +58,20 @@ julia> data = get_data(element_ids)
  3085
 ```
 
+After modifications to the read VTK data, one can write back using WriteVTK.jl but must first convert cell objects using `to_meshcells`. 
+Continuing from the REPL code above:
+```julia
+julia> using WriteVTK
+
+julia> points = get_points(vtk); cells = to_meshcells(get_cells(vtk));
+
+julia> vtk_grid("celldata_appended_binary_compressed_new.vtu", points, cells) do vtk
+         vtk["element_ids"] = data
+       end
+1-element Vector{String}:
+ "celldata_appended_binary_compressed_new.vtu"
+```
+
 Further example VTK files can be found in the
 [`ReadVTK_examples` repository](https://github.com/JuliaVTK/ReadVTK_examples).
 
@@ -107,6 +121,8 @@ Further contributions to ReadVTK have been made by the following people:
   (Charles University, Czech Republic)
 * [Boris Kaus](https://www.geosciences.uni-mainz.de/geophysics-and-geodynamics/team/univ-prof-dr-boris-kaus/)
   (Johannes-Gutenberg University Mainz, Germany)
+* [Matthew Whisenant](https://volweb2.utk.edu/~mwhisena/)
+  (University of Tennessee, Knoxville)
 
 ## License and contributing
 ReadVTK is licensed under the MIT license (see [License](@ref)).

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -58,7 +58,9 @@ julia> data = get_data(element_ids)
  3085
 ```
 
-After modifications to the read VTK data, one can write back using [WriteVTK.jl](https://github.com/JuliaVTK/WriteVTK.jl) but must first convert cell objects using `to_meshcells`. 
+After modifications to the read VTK data, one can write back using
+[WriteVTK.jl](https://github.com/JuliaVTK/WriteVTK.jl) but must first
+convert cell objects using [`to_meshcells`](@ref). 
 Continuing from the REPL code above:
 ```julia
 julia> using WriteVTK

--- a/src/ReadVTK.jl
+++ b/src/ReadVTK.jl
@@ -1155,7 +1155,7 @@ a vector of `MeshCell` objects. The latter can, e.g., be passed to the WriteVTK.
 See also: [`VTKCells`](@ref), [`VTKBase.MeshCell`](@ref)
 """
 function to_meshcells(cells::VTKCells)
-  start_offsets = [0; cells.offsets[1:end-1]] .+ 1
+  start_offsets = [0; cells.offsets[1:(end - 1)]] .+ 1
   end_offsets = cells.offsets
 
   # range doesn't work as is in Julia <=1.6, possibly update this on new LTS

--- a/src/ReadVTK.jl
+++ b/src/ReadVTK.jl
@@ -1145,7 +1145,9 @@ function to_meshcells(cells::VTKCells)
   start_offsets = [0; cells.offsets[1:end-1]] .+ 1
   end_offsets = cells.offsets
 
-  offset_ranges = range.(start_offsets, end_offsets)
+  # range doesn't work as is in Julia <=1.6, possibly update this on new LTS
+  #offset_ranges = range.(start_offsets, end_offsets)
+  offset_ranges = (:).(start_offsets, end_offsets)
 
   connectivity = getindex.([cells.connectivity], offset_ranges)
   cell_types = VTKBase.VTKCellType.(cells.types)

--- a/src/ReadVTK.jl
+++ b/src/ReadVTK.jl
@@ -16,7 +16,8 @@ export VTKFile, VTKData, VTKDataArray, VTKCells, VTKPrimitives,           # stru
        get_point_data, get_cell_data, get_data, get_data_reshaped,        # get data functions
        get_points, get_cells, get_origin, get_spacing, get_primitives,    # get geometry functions
        get_coordinates, get_coordinate_data,                              # get geometry functions
-       get_example_file                                                   # other functions
+       get_example_file,                                                  # other functions
+       to_meshcells                                                       # conversion utility
 
 """
     VTKFile
@@ -1130,6 +1131,26 @@ function get_example_file(filename; head="main", output_directory=".", force=fal
   end
 
   return filepath
+end
+
+"""
+    to_meshcells(cells::VTKCells)
+
+Convert a `VTKCells` object, which holds raw point and connectivity data for a number of cells, to
+a vector of `MeshCell` objects. The latter can, e.g., be passed to the WriteVTK.jl package for writing new VTK files.
+See also: [`VTKCells`](@ref), [`MeshCell`](@ref)
+"""
+function to_meshcells(cells::VTKCells)
+
+  start_offsets = [0; cells.offsets[1:end-1]] .+ 1
+  end_offsets = cells.offsets
+
+  offset_ranges = range.(start_offsets, end_offsets)
+
+  connectivity = getindex.([cells.connectivity], offset_ranges)
+  cell_types = VTKBase.VTKCellType.(cells.types)
+
+  return VTKBase.MeshCell.(cell_types, connectivity)
 end
 
 end # module

--- a/src/ReadVTK.jl
+++ b/src/ReadVTK.jl
@@ -1138,7 +1138,7 @@ end
 
 Convert a `VTKCells` object, which holds raw point and connectivity data for a number of cells, to
 a vector of `MeshCell` objects. The latter can, e.g., be passed to the WriteVTK.jl package for writing new VTK files.
-See also: [`VTKCells`](@ref), [`MeshCell`](@ref)
+See also: [`VTKCells`](@ref), [`VTKBase.MeshCell`](@ref)
 """
 function to_meshcells(cells::VTKCells)
 

--- a/src/ReadVTK.jl
+++ b/src/ReadVTK.jl
@@ -1141,7 +1141,6 @@ a vector of `MeshCell` objects. The latter can, e.g., be passed to the WriteVTK.
 See also: [`VTKCells`](@ref), [`VTKBase.MeshCell`](@ref)
 """
 function to_meshcells(cells::VTKCells)
-
   start_offsets = [0; cells.offsets[1:end-1]] .+ 1
   end_offsets = cells.offsets
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -103,6 +103,10 @@ clean_directory(TEST_EXAMPLES_DIR) = @test_nowarn rm(TEST_EXAMPLES_DIR, recursiv
       @test cells.connectivity[1000] == 422
     end
 
+    @testset "validate cell object conversion" begin
+      @test isa.(to_meshcells(get_cells(vtk_file)), WriteVTK.MeshCell) |> all
+    end
+
     @testset "show" begin
       @test isnothing(show(devnull, vtk_file))
       @test isnothing(show(devnull, cell_data))


### PR DESCRIPTION
This PR follows up on the accidentally closed PR #28 

This PR sets up the workflow between ReadVTK -> WriteVTK by adding `to_meshcell`. Here the changes are:

- New function `to_meshcell` that converts `VTKCells` type to multiple WriteVTK compliant `MeshCells`
- Test in the first basic testing to check for `to_meshcell` correctness
- Added example of workflow in main index page. Let me know if you want something changed.
- Added my name to contributors. My university page got cleared in a address move but will be back up in a week or so. This new address will be the permanent one so no need for a recommit.
- Added .vscode to gitignore to help vscode users settings not mess with commits. Helps me not added whitespace to commits.

Note that I separated PRs in this to make more sense on an orthogonal feature level. My next PR will include more inclusive testing of ReadVTK -> WriteVTK workflow with ParaView and standard files. But this single test should at least cover testing of the conversion in and of itself.

This PR must be accepted before the larger ParaView one, but I figured it was worth it for clarity to split them up.
