### PR TITLE
Bugfix - reading appended_data

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ReadVTK"
 uuid = "dc215faf-f008-4882-a9f7-a79a826fadc3"
 authors = ["Michael Schlottke-Lakemper <michael@sloede.com>"]
-version = "0.1.7-pre"
+version = "0.1.7"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/ReadVTK.jl
+++ b/src/ReadVTK.jl
@@ -96,7 +96,13 @@ function VTKFile(filename)
     # library
     offset_begin = first(findnext("_", raw_file_contents, last(marker))) + 1
     offset_end = first(findnext("</AppendedData>", raw_file_contents, offset_begin)) - 1
-    appended_data = Vector{UInt8}(rstrip(raw_file_contents[offset_begin:offset_end]))
+  
+    #appended_data = Vector{UInt8}(rstrip(raw_file_contents[offset_begin:offset_end]))
+    # rstrip was used earlier, but removes a space at the end of the line, which can cause havoc 
+    # in case raw_file_contents ends with a space, such as 
+    # "... (f\x12 \n\t", which will be turned into "... (f\x12" 
+    appended_data = Vector{UInt8}(raw_file_contents[offset_begin:offset_end][1:end-2])
+    
     xml_file_contents = (raw_file_contents[1:(offset_begin - 1)] *
                          "\n  </AppendedData>\n</VTKFile>")
   end

--- a/src/ReadVTK.jl
+++ b/src/ReadVTK.jl
@@ -96,13 +96,13 @@ function VTKFile(filename)
     # library
     offset_begin = first(findnext("_", raw_file_contents, last(marker))) + 1
     offset_end = first(findnext("</AppendedData>", raw_file_contents, offset_begin)) - 1
-  
+
     #appended_data = Vector{UInt8}(rstrip(raw_file_contents[offset_begin:offset_end]))
     # rstrip was used earlier, but removes a space at the end of the line, which can cause havoc 
     # in case raw_file_contents ends with a space, such as 
     # "... (f\x12 \n\t", which will be turned into "... (f\x12" 
-    appended_data = Vector{UInt8}(raw_file_contents[offset_begin:offset_end][1:end-2])
-    
+    appended_data = Vector{UInt8}(raw_file_contents[offset_begin:offset_end][1:(end - 2)])
+
     xml_file_contents = (raw_file_contents[1:(offset_begin - 1)] *
                          "\n  </AppendedData>\n</VTKFile>")
   end

--- a/src/ReadVTK.jl
+++ b/src/ReadVTK.jl
@@ -96,12 +96,7 @@ function VTKFile(filename)
     # library
     offset_begin = first(findnext("_", raw_file_contents, last(marker))) + 1
     offset_end = first(findnext("</AppendedData>", raw_file_contents, offset_begin)) - 1
-
-    #appended_data = Vector{UInt8}(rstrip(raw_file_contents[offset_begin:offset_end]))
-    # rstrip was used earlier, but removes a space at the end of the line, which can cause havoc 
-    # in case raw_file_contents ends with a space, such as 
-    # "... (f\x12 \n\t", which will be turned into "... (f\x12" 
-    appended_data = Vector{UInt8}(raw_file_contents[offset_begin:offset_end][1:(end - 2)])
+    appended_data = Vector{UInt8}(raw_file_contents[offset_begin:offset_end])
 
     xml_file_contents = (raw_file_contents[1:(offset_begin - 1)] *
                          "\n  </AppendedData>\n</VTKFile>")

--- a/test/rectilinear.jl
+++ b/test/rectilinear.jl
@@ -134,8 +134,10 @@ for compress in [true, false]
   end
 end
 
-# Testfile with trailing whitespace 
-vtr_file = VTKFile(get_test_example_file("pointdata_appended_binary_with_trailing_whitespace.vtr"))
-point_data = get_point_data(vtr_file)
-data = get_data_reshaped(point_data[point_data.names[9]]);
-@test size(data) == (129, 2, 65)
+@testset "trailing whitespace in appended data" begin
+  # Testfile with trailing whitespace 
+  vtr_file = VTKFile(get_test_example_file("pointdata_appended_binary_with_trailing_whitespace.vtr"))
+  point_data = get_point_data(vtr_file)
+  data = get_data_reshaped(point_data[point_data.names[9]])
+  @test size(data) == (129, 2, 65)
+end

--- a/test/rectilinear.jl
+++ b/test/rectilinear.jl
@@ -133,3 +133,9 @@ for compress in [true, false]
 
   end
 end
+
+# Testfile with trailing whitespace 
+vtr_file = VTKFile(get_test_example_file("pointdata_appended_binary_with_trailing_whitespace.vtr"))
+point_data = get_point_data(vtr_file)
+data = get_data_reshaped(point_data[point_data.names[9]]);
+@test size(data) == (129, 2, 65)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,7 +6,7 @@ using ReadVTK, WriteVTK
 # Note: The purpose of using a specific commit hash (instead of `main`) is to be able to tie a given
 #       version of ReadVTK to a specific version of the test file repository. This way, also tests
 #       for older ReadVTK releases should continue to work.
-TEST_EXAMPLES_COMMIT = "1178cafb12bfac2a6d249f3ef0da9423f6c7202e"
+TEST_EXAMPLES_COMMIT = "1f961a7ad38e76a8d552b8392d8cd661ab9f79b4"
 
 # Local folder to store downloaded example files. If you change this, also adapt `../.gitignore`!
 TEST_EXAMPLES_DIR = "examples"


### PR DESCRIPTION
This fixes a bug that occurred irregularly (with files that could be read fine by Paraview). 
The culprit turns out to be the following line in `VTKFile(filename)`:
```Julia
appended_data = Vector{UInt8}(rstrip(raw_file_contents[offset_begin:offset_end]))
```
The issue is that `raw_file_contents` sometimes ends in a space as in `(f\x12 \n\t"` which `rstrip` changes to `(f\x12"` instead of `(f\x12 "`.
Fixed with:
```Julia
appended_data = Vector{UInt8}(raw_file_contents[offset_begin:offset_end][1:end-2])
```
Here a ZIP-file that has the problem:
[Convection_p00000000.vtr.zip](https://github.com/JuliaVTK/ReadVTK.jl/files/11411654/Convection_p00000000.vtr.zip)
reproduce the mistake with:
```Julia
julia> vtk_read = VTKFile("Convection_p00000000.vtr");
julia> point_data = get_point_data(vtk_read);
julia> get_data_reshaped(point_data[point_data.names[9]]);
ERROR: BoundsError: attempt to access 738759-element Vector{UInt8} at index [671681:738760]
Stacktrace:
 [1] throw_boundserror(A::Vector{UInt8}, I::Tuple{UnitRange{Int64}})
   @ Base ./abstractarray.jl:703
 [2] checkbounds
   @ ./abstractarray.jl:668 [inlined]
 [3] view
   @ ./subarray.jl:177 [inlined]
 [4] get_data(data_array::VTKDataArray{Float32, 1, ReadVTK.FormatAppended})
   @ ReadVTK ~/Downloads/ReadVTK.jl/src/ReadVTK.jl:756
 [5] #get_data_reshaped#5
   @ ~/Downloads/ReadVTK.jl/src/ReadVTK.jl:792 [inlined]
 [6] get_data_reshaped(data_array::VTKDataArray{Float32, 1, ReadVTK.FormatAppended})
   @ ReadVTK ~/Downloads/ReadVTK.jl/src/ReadVTK.jl:791
 [7] top-level scope
   @ REPL[11]:1
```


