### PR TITLE
Update/add show functions VTK objects

### DIFF
--- a/src/ReadVTK.jl
+++ b/src/ReadVTK.jl
@@ -164,21 +164,19 @@ end
 
 # Show basic information on REPL
 function Base.show(io::IO, vtk_file::VTKFile)
-  return print(
-    io, 
-    repr(typeof(vtk_file)),
-    "(",
-      repr(vtk_file.filename), ", ",
-      "<XMLDocument>, ",
-      repr(vtk_file.file_type), ", ",
-      repr(vtk_file.version), ", ",
-      repr(vtk_file.byte_order), ", ",
-      repr(vtk_file.compressor), ", ",
-      "<appended_data>, ",
-      repr(vtk_file.n_points), ", ",
-      repr(vtk_file.n_cells), 
-    ")"
-  )
+  return print(io,
+               repr(typeof(vtk_file)),
+               "(",
+               repr(vtk_file.filename), ", ",
+               "<XMLDocument>, ",
+               repr(vtk_file.file_type), ", ",
+               repr(vtk_file.version), ", ",
+               repr(vtk_file.byte_order), ", ",
+               repr(vtk_file.compressor), ", ",
+               "<appended_data>, ",
+               repr(vtk_file.n_points), ", ",
+               repr(vtk_file.n_cells),
+               ")")
 end
 
 # Return `Piece` XML element that contains all VTK data
@@ -275,18 +273,16 @@ end
 
 # Show basic information on REPL
 function Base.show(io::IO, pvtk_file::PVTKFile)
-  return print(
-    io, 
-    repr(typeof(pvtk_file)),
-    "(",
-      repr(pvtk_file.filename), ", ",
-      "<XMLDocument>, ",
-      repr(pvtk_file.file_type), ", ",
-      repr(pvtk_file.version), ", ",
-      repr(pvtk_file.vtk_filenames), ", ",
-      "<vtk_files>", 
-    ")"
-  )
+  return print(io,
+               repr(typeof(pvtk_file)),
+               "(",
+               repr(pvtk_file.filename), ", ",
+               "<XMLDocument>, ",
+               repr(pvtk_file.file_type), ", ",
+               repr(pvtk_file.version), ", ",
+               repr(pvtk_file.vtk_filenames), ", ",
+               "<vtk_files>",
+               ")")
 end
 
 """
@@ -351,17 +347,15 @@ end
 
 # Show basic information on REPL
 function Base.show(io::IO, pvd_file::PVDFile)
-  return print(
-    io, 
-    repr(typeof(pvd_file)),
-    "(",
-      repr(pvd_file.filename), ", ",
-      repr(pvd_file.file_type), ", ",
-      "<vtk_filenames>, ",
-      "<directories>, ",
-      "<timesteps>",
-    ")"
-  )
+  return print(io,
+               repr(typeof(pvd_file)),
+               "(",
+               repr(pvd_file.filename), ", ",
+               repr(pvd_file.file_type), ", ",
+               "<vtk_filenames>, ",
+               "<directories>, ",
+               "<timesteps>",
+               ")")
 end
 
 
@@ -387,15 +381,13 @@ end
 
 # Show basic information on REPL
 function Base.show(io::IO, vtk_data::VTKData)
-  return print(
-    io, 
-    repr(typeof(vtk_data)),
-    "(",
-      repr(vtk_data.names), ", ",
-      "<data_arrays>, ",
-      "<VTKFile>",
-    ")"
-  )
+  return print(io,
+               repr(typeof(vtk_data)),
+               "(",
+               repr(vtk_data.names), ", ",
+               "<data_arrays>, ",
+               "<VTKFile>",
+               ")")
 end
 
 """
@@ -413,14 +405,12 @@ end
 
 # Show basic information on REPL
 function Base.show(io::IO, pvtk_data::PVTKData)
-  return print(
-    io, 
-    repr(typeof(pvtk_data)),
-    "(",
-      "<parent_xml>, ",
-      "<$(summary(pvtk_data.data))>",
-    ")"
-  )
+  return print(io,
+               repr(typeof(pvtk_data)),
+               "(",
+               "<parent_xml>, ",
+               "<$(summary(pvtk_data.data))>",
+               ")")
 end
 
 
@@ -608,14 +598,12 @@ end
 
 # Show basic information on REPL
 function Base.show(io::IO, pvtk_data_array::PVTKDataArray)
-  return print(
-    io, 
-    string(typeof(pvtk_data_array)),
-    "(",
-      "<parent_xml>, ",
-      "<$(summary(pvtk_data_array.data))>",
-    ")"
-  )
+  return print(io,
+               string(typeof(pvtk_data_array)),
+               "(",
+               "<parent_xml>, ",
+               "<$(summary(pvtk_data_array.data))>",
+               ")")
 end
 
 # Auxiliary types for type stability
@@ -701,16 +689,14 @@ end
 
 # Show basic information on REPL
 function Base.show(io::IO, vtk_data_array::VTKDataArray)
-  return print(
-    io,
-    repr(typeof(vtk_data_array)),
-    "(",
-      repr(vtk_data_array.name), ", ",
-      repr(vtk_data_array.offset), ", ",
-      repr(vtk_data_array.data_array), ", ",
-      "<VTKFile>",
-    ")"
-  )
+  return print(io,
+               repr(typeof(vtk_data_array)),
+               "(",
+               repr(vtk_data_array.name), ", ",
+               repr(vtk_data_array.offset), ", ",
+               repr(vtk_data_array.data_array), ", ",
+               "<VTKFile>",
+               ")")
 end
 
 # Return true if data is compressed (= XML attribute `compressor` is non-empty in VTK file)

--- a/src/ReadVTK.jl
+++ b/src/ReadVTK.jl
@@ -167,16 +167,21 @@ end
 
 # Show basic information on REPL
 function Base.show(io::IO, vtk_file::VTKFile)
-  return print(io, "VTKFile(",
-               "\"", vtk_file.filename, "\", ",
-               "<XMLDocument>", ", ",
-               "\"", vtk_file.file_type, "\", ",
-               "\"", vtk_file.version, "\", ",
-               "\"", vtk_file.byte_order, "\", ",
-               "\"", vtk_file.compressor, "\", ",
-               "<appended_data>", ", ",
-               vtk_file.n_points, ", ",
-               vtk_file.n_cells, ")")
+  return print(
+    io, 
+    repr(typeof(vtk_file)),
+    "(",
+      repr(vtk_file.filename), ", ",
+      "<XMLDocument>, ",
+      repr(vtk_file.file_type), ", ",
+      repr(vtk_file.version), ", ",
+      repr(vtk_file.byte_order), ", ",
+      repr(vtk_file.compressor), ", ",
+      "<appended_data>, ",
+      repr(vtk_file.n_points), ", ",
+      repr(vtk_file.n_cells), 
+    ")"
+  )
 end
 
 # Return `Piece` XML element that contains all VTK data
@@ -274,9 +279,20 @@ function PVTKFile(filename; dir = "")
   return PVTKFile(filename, xml_file, file_type, version, vtk_filenames, vtk_files)
 end
 
-# Reduce noise:
-function Base.show(io::IO, vtk_file::PVTKFile)
-  return print(io, "PVTKFile()")
+# Show basic information on REPL
+function Base.show(io::IO, pvtk_file::PVTKFile)
+  return print(
+    io, 
+    repr(typeof(pvtk_file)),
+    "(",
+      repr(pvtk_file.filename), ", ",
+      "<XMLDocument>, ",
+      repr(pvtk_file.file_type), ", ",
+      repr(pvtk_file.version), ", ",
+      repr(pvtk_file.vtk_filenames), ", ",
+      "<vtk_files>", 
+    ")"
+  )
 end
 
 """
@@ -342,9 +358,19 @@ function PVDFile(filename)
   return PVDFile(filename, file_type, vtk_filenames, directories, timesteps)
 end
 
-# Reduce noise:
-function Base.show(io::IO, d::PVDFile)
-  return print(io, "PVDFile()")
+# Show basic information on REPL
+function Base.show(io::IO, pvd_file::PVDFile)
+  return print(
+    io, 
+    repr(typeof(pvd_file)),
+    "(",
+      repr(pvd_file.filename), ", ",
+      repr(pvd_file.file_type), ", ",
+      "<vtk_filenames>, ",
+      "<directories>, ",
+      "<timesteps>",
+    ")"
+  )
 end
 
 
@@ -368,8 +394,18 @@ struct VTKData
   vtk_file::VTKFile
 end
 
-# Reduce REPL noise by defining `show`
-Base.show(io::IO, data::VTKData) = print(io, "VTKData()")
+# Show basic information on REPL
+function Base.show(io::IO, vtk_data::VTKData)
+  return print(
+    io, 
+    repr(typeof(vtk_data)),
+    "(",
+      repr(vtk_data.names), ", ",
+      "<data_arrays>, ",
+      "<VTKFile>",
+    ")"
+  )
+end
 
 """
     PVTKData
@@ -384,8 +420,17 @@ struct PVTKData
   data::Vector{VTKData}
 end
 
-# Reduce REPL noise by defining `show`
-Base.show(io::IO, data::PVTKData) = print(io, "PVTKData()")
+# Show basic information on REPL
+function Base.show(io::IO, pvtk_data::PVTKData)
+  return print(
+    io, 
+    repr(typeof(pvtk_data)),
+    "(",
+      "<parent_xml>, ",
+      "<$(summary(pvtk_data.data))>",
+    ")"
+  )
+end
 
 
 # Retrieve a data section (should be `CellData` or `PointData`) from the VTK file
@@ -570,7 +615,17 @@ struct PVTKDataArray
   data::Vector{VTKDataArray}
 end
 
-Base.show(io::IO, vtk_file::PVTKDataArray) = print(io, "PVTKDataArray()")
+# Show basic information on REPL
+function Base.show(io::IO, pvtk_data_array::PVTKDataArray)
+  return print(
+    io, 
+    string(typeof(pvtk_data_array)),
+    "(",
+      "<parent_xml>, ",
+      "<$(summary(pvtk_data_array.data))>",
+    ")"
+  )
+end
 
 # Auxiliary types for type stability
 struct FormatBinary end
@@ -653,9 +708,18 @@ function VTKDataArray(xml_element, vtk_file::VTKFile)
   return VTKDataArray{data_type, n_components, format}(name, offset, xml_element, vtk_file)
 end
 
-# Reduce REPL noise by defining `show`
-function Base.show(io::IO, data_array::VTKDataArray)
-  return print(io, "VTKDataArray(\"", data_array.name, "\")")
+# Show basic information on REPL
+function Base.show(io::IO, vtk_data_array::VTKDataArray)
+  return print(
+    io,
+    repr(typeof(vtk_data_array)),
+    "(",
+      repr(vtk_data_array.name), ", ",
+      repr(vtk_data_array.offset), ", ",
+      repr(vtk_data_array.data_array), ", ",
+      "<VTKFile>",
+    ")"
+  )
 end
 
 # Return true if data is compressed (= XML attribute `compressor` is non-empty in VTK file)

--- a/test/pvtk_files.jl
+++ b/test/pvtk_files.jl
@@ -170,6 +170,7 @@ cd(TEST_EXAMPLES_DIR)
   # Extract data
   point_data = get_point_data(pvtk)
 
+  @test isnothing(show(devnull, point_data))
   @test firstindex(point_data) == "Temperature"
   @test lastindex(point_data) == "Velocity"
   @test length(point_data) == 2


### PR DESCRIPTION
The following pull request updates and adds `show` methods for various VTK objects, following this issue: https://github.com/JuliaVTK/ReadVTK.jl/issues/60

Updated and added methods are given for the following objects: 
- `VTKFile`,
- `VTKDataArray`,
- `PVTKFile`, 
- `PVDFile`, 
- `VTKData`, 
- `PVTKData`, and 
- `PVTKDataArray`.

Where possible, I have tried to copy the style of the original `show` method defined for `VTKFile` objects.

The following subsections show a comparison of the original `show` output verses the proposed new `show` output (generated from files in the test suite).

### `VTKFile` objects

#### Original output
```
VTKFile("./celldata_appended_binary_compressed.vtu", <XMLDocument>, "UnstructuredGrid", "1.0.0", "LittleEndian", "vtkZLibDataCompressor", <appended_data>, 4434, 3085)
```

#### Proposed new output
```
VTKFile("./celldata_appended_binary_compressed.vtu", <XMLDocument>, "UnstructuredGrid", v"1.0.0", "LittleEndian", "vtkZLibDataCompressor", <appended_data>, 4434, 3085)
```

#### Notes

The proposed changes are only slightly different than the current implementation. The only difference is using the `repr` representation for the `vtk_file.version::VersionNumber`.

### `VTKDataArray` objects

#### Original output
```
VTKDataArray("element_ids")
```

#### Proposed new output
```
VTKDataArray{Int64, 1, ReadVTK.FormatAppended}("element_ids", 32675, <DataArray type="Int64" Name="element_ids" NumberOfComponents="1" format="appended" offset="32675"/>, <VTKFile>)
```

#### Notes

The new `show` method lists the parametric types associated with the object, listing the data type encoding, the size of the second dimension, and the encodingformat`. It also lists the other data fields, with a shortened expression for the `vtk_file` field (shortened similarly to the method defined for `VTKFile`). 

### `PVTKFile` objects

#### Original output
```
PVTKFile()
```

#### Proposed new output
```
PVTKFile("fields.pvtr", <XMLDocument>, "PRectilinearGrid", v"1.0.0", ["fields/fields_1.vtr", "fields/fields_2.vtr", "fields/fields_3.vtr", "fields/fields_4.vtr"], <vtk_files>)
```

#### Notes

Similar format to `VTKFile`, but including a list representation for the field `vtk_filenames::Vector{String}`.

### `PVDFile` objects:

#### Original output
```
PVDFile()
```

#### Proposed new output
```
PVDFile("full_simulation.pvd", "Collection", <vtk_filenames>, <directories>, <timesteps>)
```

#### Notes

Similar format to `VTKFile`,  but many of the fields now have shortened expressions.

### `VTKData` objects:

#### Original output
```
VTKData()
```

#### Proposed new output
```
VTKData(["cell_ids", "element_ids", "levels", "indicator_amr", "indicator_shock_capturing"], <data_arrays>, <VTKFile>)
```

#### Notes

Here the new method shows the array for `names::Vector{String}`, and only short expressions for the other fields.

### `PVTKData` objects:

#### Original output
```
PVTKData()
```

#### Proposed new output
```
PVTKData(<parent_xml>, <4-element Vector{VTKData}>)
```

#### Notes

Similar to `VTKData`, but here the field `data::Vector{VTKData}` uses the `summary` method for the shown string.

### `PVTKDataArray` objects:

#### Original output
```
PVTKDataArray()
```

#### Proposed new output
```
PVTKDataArray(<parent_xml>, <4-element Vector{VTKDataArray}>)
```

#### Notes

Similar to `PVTKData`, where the field `data::Vector{VTKDataArray}` uses the `summary` method for the shown string.

## Reasoning and justification for changes

Informative `show` methods help new users understand the functionality of the package, and help debugging.

## Comments

Where possible, I have tried to copy the style and code formatting of the original `show` method defined for `VTKFile` objects. This is my first attempt at changes, and I'm happy to take on feedback, thank you!
