### PR TITLE
fix tests for WriteVTK.jl v1.19 and run new version of the formatter

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -37,7 +37,7 @@ makedocs(
            "Reference" => "reference.md",
            "VTKBase.jl" => vtkbase_docs,
            "Contributing" => "contributing.md",
-           "License" => "license.md",
+           "License" => "license.md"
          ])
 
 deploydocs(repo = "github.com/JuliaVTK/ReadVTK.jl",

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,8 +1,9 @@
 [deps]
+ReadVTK = "dc215faf-f008-4882-a9f7-a79a826fadc3"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 WriteVTK = "64499a7a-5c06-52f2-abe2-ccb03c286192"
 
 [compat]
 StaticArrays = "1"
-WriteVTK = "1.13"
+WriteVTK = "1.19"

--- a/test/pvtk_files.jl
+++ b/test/pvtk_files.jl
@@ -23,7 +23,7 @@ extents = [
   (1:10, 1:5, 1:4),   # process 1
   (10:15, 1:5, 1:4),  # process 2
   (1:10, 5:12, 1:4),  # process 3
-  (10:15, 5:12, 1:4), # process 4
+  (10:15, 5:12, 1:4) # process 4
 ]
 
 saved_files = Vector{Vector{String}}(undef, 4)  # files saved by each "process"
@@ -102,14 +102,14 @@ all_data = [
   (points = rand(3, 5),  # 5 points on process 1
    cells = [             # 2 cells  on process 1
      MeshCell(VTKCellTypes.VTK_TRIANGLE, [1, 4, 2]),
-     MeshCell(VTKCellTypes.VTK_QUAD, [2, 4, 3, 5]),
+     MeshCell(VTKCellTypes.VTK_QUAD, [2, 4, 3, 5])
    ]),
 
   # Process 2
   (points = rand(3, 4),  # 4 points on process 2
    cells = [             # 1 cell   on process 2
-     MeshCell(VTKCellTypes.VTK_QUAD, [1, 2, 3, 4]),
-   ]),
+     MeshCell(VTKCellTypes.VTK_QUAD, [1, 2, 3, 4])
+   ])
 ]
 
 saved_files = Vector{Vector{String}}(undef, 2)  # files saved by each "process"

--- a/test/pvtk_files.jl
+++ b/test/pvtk_files.jl
@@ -143,6 +143,13 @@ saved_files = paraview_collection(path_pvd) do pvd
 end
 
 # (2) Read back files
+# Since WriteVTK uses relative paths, we need to change to the directory where
+# the files were saved. We remember the current directory and change back to it
+# at the end of the test.
+# See https://github.com/JuliaVTK/WriteVTK.jl/pull/141 and
+# https://github.com/JuliaVTK/ReadVTK.jl/pull/62
+current_directory = pwd()
+cd(TEST_EXAMPLES_DIR)
 
 # a) RectilinearGrid file
 @testset "pvtr" begin
@@ -280,3 +287,6 @@ end
   @test pvd.timesteps == Vector(times)
   @test isnothing(show(devnull, pvd))
 end
+
+# Change back to the original directory
+cd(current_directory)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,7 +9,7 @@ using ReadVTK, WriteVTK
 TEST_EXAMPLES_COMMIT = "1f961a7ad38e76a8d552b8392d8cd661ab9f79b4"
 
 # Local folder to store downloaded example files. If you change this, also adapt `../.gitignore`!
-TEST_EXAMPLES_DIR = "examples"
+TEST_EXAMPLES_DIR = abspath("examples")
 
 
 function get_test_example_file(filename)


### PR DESCRIPTION
Since #61 failed, I wanted to test CI here and also ran the newest version of the formatter.